### PR TITLE
Fix stray symbol after screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ Tickscope is a real-time market data visualization tool. This repository contain
   
   ![Python Version Screenshot](docs/images/python-screenshot.png)
 
-  ▶️ [Watch Python Version Demo](https://youtu.be/jjH9sx_A8j4?vq=hd2160)
 
 - **Swift Version** (`swift-version` branch): A macOS-native application built with Swift and SwiftUI.
 
   ![Swift Version Screenshot](docs/images/swift-screenshot.png)
 
-  ▶️ [Watch Swift Version Demo](https://youtu.be/gcE7muerhAI?vq=hd2160)
 
 ## Switching Between Versions
 


### PR DESCRIPTION
## Summary
- remove demo link lines so only screenshots show

## Testing
- `grep -n "▶" README.md`