### PR TITLE
Implement STOMP connect and session token flow

### DIFF
--- a/tickscope/IBKRWebSocketManager.swift
+++ b/tickscope/IBKRWebSocketManager.swift
@@ -59,7 +59,13 @@ final class IBKRWebSocketManager: ObservableObject {
         let conIdString = conIds.map(String.init).joined(separator: ",")
         print("🌐 WS connecting to", url, "for", conIdString)
         webSocketTask?.resume()
-        status = .connected
+
+        // Initial STOMP handshake
+        let connect = "CONNECT\naccept-version:1.2\nheart-beat:10000,10000\n\n\0"
+        webSocketTask?.send(.string(connect)) { if let e = $0 { self.connectionError = e } }
+        sendStomp(command: "SUBSCRIBE",
+                  headers: ["destination": "System", "id": "system"],
+                  body: nil)
 
         if sessionToken != nil {
             subscribe(conIds: conIds)
@@ -160,6 +166,7 @@ final class IBKRWebSocketManager: ObservableObject {
                     subscribe(conIds: pendingConIds)
                     pendingConIds.removeAll()
                 }
+                status = .connected
                 return
             }
             parseMarketData(obj); trimOldData(); return


### PR DESCRIPTION
## Summary
- establish STOMP handshake when opening the web socket
- subscribe to the `system` topic to get the session token
- mark the connection as connected once the token arrives

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840543174b4832588d66f677c1312a7