### PR TITLE
Ensure WebSocket tasks reset on reconnect

### DIFF
--- a/tickscope/WebSocketManager.swift
+++ b/tickscope/WebSocketManager.swift
@@ -51,6 +51,8 @@ class WebSocketManager: ObservableObject {
 
     /// ✅ Calls `resetData()` before connecting to a new ticker
     func connect(stockTicker: String, optionTicker: String) {
+        // Cancel any existing tasks so they don't continue running when reconnecting
+        disconnect()
         resetData() // Clear all data before reconnecting
 
         connectStockWebSocket(stockTicker: stockTicker)
@@ -227,7 +229,9 @@ class WebSocketManager: ObservableObject {
 
     func disconnect() {
         stockWebSocket?.cancel()
+        stockWebSocket = nil
         optionWebSocket?.cancel()
+        optionWebSocket = nil
     }
     
     private func updateOptionChartsTimestamp() {


### PR DESCRIPTION
## Summary
- disconnect existing web sockets before reconnecting
- clear references to tasks after cancelling

## Testing
- `swiftc tickscope/WebSocketManager.swift -o /tmp/wsmanager` *(fails: cannot find Combine and other frameworks)*

------
https://chatgpt.com/codex/tasks/task_e_68861e9ae4ac83258fe62abcfe1d28c0