### PR TITLE
Fix ForEach ids for repeated timestamps

### DIFF
--- a/tickscope/BidAskOptionChartView.swift
+++ b/tickscope/BidAskOptionChartView.swift
@@ -11,7 +11,7 @@ struct BidAskOptionChartView: View {
                 .padding()
 
             Chart {
-                ForEach(webSocketManager.bidAskOptionPrices, id: \.timestamp) { quote in
+                ForEach(webSocketManager.bidAskOptionPrices, id: \.id) { quote in
                     PointMark( // ✅ Marker for Bids
                         x: .value("Time", quote.timestamp),
                         y: .value("Bid", quote.bidPrice)

--- a/tickscope/BidAskStockChartView.swift
+++ b/tickscope/BidAskStockChartView.swift
@@ -11,7 +11,7 @@ struct BidAskStockChartView: View {
                 .padding()
 
             Chart {
-                ForEach(webSocketManager.bidAskStockPrices, id: \.timestamp) { quote in
+                ForEach(webSocketManager.bidAskStockPrices, id: \.id) { quote in
                     PointMark( // ✅ Marker for Bids
                         x: .value("Time", quote.timestamp),
                         y: .value("Bid", quote.bidPrice)

--- a/tickscope/OptionPriceChartView.swift
+++ b/tickscope/OptionPriceChartView.swift
@@ -18,7 +18,7 @@ struct OptionPriceChartView: View {
                 .padding()
 
             Chart {
-                ForEach(webSocketManager.optionTradePrices, id: \.timestamp) { trade in
+                ForEach(webSocketManager.optionTradePrices, id: \.id) { trade in
                     PointMark(
                         x: .value("Time", trade.timestamp),
                         y: .value("Price", trade.price)

--- a/tickscope/StockPriceChartView.swift
+++ b/tickscope/StockPriceChartView.swift
@@ -11,7 +11,7 @@ struct StockPriceChartView: View {
                 .padding()
 
             Chart {
-                ForEach(webSocketManager.tradePrices, id: \.timestamp) { trade in
+                ForEach(webSocketManager.tradePrices, id: \.id) { trade in
                     PointMark(
                         x: .value("Time", trade.timestamp),
                         y: .value("Price", trade.price)

--- a/tickscope/VolumeStockChartView.swift
+++ b/tickscope/VolumeStockChartView.swift
@@ -19,7 +19,7 @@ struct VolumeStockChartView: View {
                 .padding()
 
             Chart {
-                ForEach(webSocketManager.stockVolumes, id: \.timestamp) { volume in
+                ForEach(webSocketManager.stockVolumes, id: \.id) { volume in
                     BarMark(
                         x: .value("Time", volume.timestamp),
                         y: .value("Volume", volume.volume)


### PR DESCRIPTION
## Summary
- use unique `.id` for ForEach loops across chart views

This ensures repeated timestamps still render every data point because the models already conform to `Identifiable`.

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_68861f89c37c8325ab370b73e70a3a9b