### PR TITLE
Add tests for option utilities

### DIFF
--- a/tickscope.xcodeproj/project.pbxproj
+++ b/tickscope.xcodeproj/project.pbxproj
@@ -7,70 +7,126 @@
 	objects = {
 
 /* Begin PBXFileReference section */
-		90191C882D801E1300C8E23E /* tickscope.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = tickscope.app; sourceTree = BUILT_PRODUCTS_DIR; };
+               90191C882D801E1300C8E23E /* tickscope.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = tickscope.app; sourceTree = BUILT_PRODUCTS_DIR; };
+               90191D0C2D801E1300C8E23E /* tickscopeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = tickscopeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		90191C8A2D801E1300C8E23E /* tickscope */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = tickscope;
-			sourceTree = "<group>";
-		};
+                90191C8A2D801E1300C8E23E /* tickscope */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = tickscope;
+                        sourceTree = "<group>";
+                };
+               90191D0B2D801E1300C8E23E /* tickscopeTests */ = {
+                        isa = PBXFileSystemSynchronizedRootGroup;
+                        path = tickscopeTests;
+                        sourceTree = "<group>";
+                };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		90191C852D801E1300C8E23E /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                90191C852D801E1300C8E23E /* Frameworks */ = {
+                        isa = PBXFrameworksBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+               90191D0E2D801E1300C8E23E /* Frameworks */ = {
+                        isa = PBXFrameworksBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		90191C7F2D801E1300C8E23E = {
-			isa = PBXGroup;
-			children = (
-				90191C8A2D801E1300C8E23E /* tickscope */,
-				90191C892D801E1300C8E23E /* Products */,
-			);
-			sourceTree = "<group>";
-		};
-		90191C892D801E1300C8E23E /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				90191C882D801E1300C8E23E /* tickscope.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
+                90191C7F2D801E1300C8E23E = {
+                        isa = PBXGroup;
+                        children = (
+                                90191C8A2D801E1300C8E23E /* tickscope */,
+                                90191D0B2D801E1300C8E23E /* tickscopeTests */,
+                                90191C892D801E1300C8E23E /* Products */,
+                        );
+                        sourceTree = "<group>";
+                };
+                90191C892D801E1300C8E23E /* Products */ = {
+                        isa = PBXGroup;
+                        children = (
+                                90191C882D801E1300C8E23E /* tickscope.app */,
+                                90191D0C2D801E1300C8E23E /* tickscopeTests.xctest */,
+                        );
+                        name = Products;
+                        sourceTree = "<group>";
+                };
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		90191C872D801E1300C8E23E /* tickscope */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 90191C972D801E1300C8E23E /* Build configuration list for PBXNativeTarget "tickscope" */;
-			buildPhases = (
-				90191C842D801E1300C8E23E /* Sources */,
-				90191C852D801E1300C8E23E /* Frameworks */,
-				90191C862D801E1300C8E23E /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			fileSystemSynchronizedGroups = (
-				90191C8A2D801E1300C8E23E /* tickscope */,
-			);
-			name = tickscope;
-			packageProductDependencies = (
-			);
-			productName = tickscope;
-			productReference = 90191C882D801E1300C8E23E /* tickscope.app */;
-			productType = "com.apple.product-type.application";
-		};
+                90191C872D801E1300C8E23E /* tickscope */ = {
+                        isa = PBXNativeTarget;
+                        buildConfigurationList = 90191C972D801E1300C8E23E /* Build configuration list for PBXNativeTarget "tickscope" */;
+                        buildPhases = (
+                                90191C842D801E1300C8E23E /* Sources */,
+                                90191C852D801E1300C8E23E /* Frameworks */,
+                                90191C862D801E1300C8E23E /* Resources */,
+                        );
+                        buildRules = (
+                        );
+                        dependencies = (
+                        );
+                        fileSystemSynchronizedGroups = (
+                                90191C8A2D801E1300C8E23E /* tickscope */,
+                        );
+                        name = tickscope;
+                        packageProductDependencies = (
+                        );
+                        productName = tickscope;
+                        productReference = 90191C882D801E1300C8E23E /* tickscope.app */;
+                        productType = "com.apple.product-type.application";
+                };
+               90191D132D801E1300C8E23E /* tickscopeTests */ = {
+                        isa = PBXNativeTarget;
+                        buildConfigurationList = 90191D122D801E1300C8E23E /* Build configuration list for PBXNativeTarget "tickscopeTests" */;
+                        buildPhases = (
+                                90191D0D2D801E1300C8E23E /* Sources */,
+                                90191D0E2D801E1300C8E23E /* Frameworks */,
+                                90191D0F2D801E1300C8E23E /* Resources */,
+                        );
+                        buildRules = (
+                        );
+                        dependencies = (
+                                90191D152D801E1300C8E23E /* PBXTargetDependency */,
+                        );
+                        fileSystemSynchronizedGroups = (
+                                90191D0B2D801E1300C8E23E /* tickscopeTests */,
+                        );
+                        name = tickscopeTests;
+                        packageProductDependencies = (
+                        );
+                        productName = tickscopeTests;
+                        productReference = 90191D0C2D801E1300C8E23E /* tickscopeTests.xctest */;
+                        productType = "com.apple.product-type.bundle.unit-test";
+                };
 /* End PBXNativeTarget section */
+
+/* Begin PBXContainerItemProxy section */
+               90191D142D801E1300C8E23E /* PBXContainerItemProxy */ = {
+                        isa = PBXContainerItemProxy;
+                        containerPortal = 90191C802D801E1300C8E23E /* Project object */;
+                        proxyType = 1;
+                        remoteGlobalIDString = 90191C872D801E1300C8E23E;
+                        remoteInfo = tickscope;
+                };
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXTargetDependency section */
+               90191D152D801E1300C8E23E /* PBXTargetDependency */ = {
+                        isa = PBXTargetDependency;
+                        target = 90191C872D801E1300C8E23E /* tickscope */;
+                        targetProxy = 90191D142D801E1300C8E23E /* PBXContainerItemProxy */;
+                };
+/* End PBXTargetDependency section */
 
 /* Begin PBXProject section */
 		90191C802D801E1300C8E23E /* Project object */ = {
@@ -79,11 +135,14 @@
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1620;
 				LastUpgradeCheck = 1620;
-				TargetAttributes = {
-					90191C872D801E1300C8E23E = {
-						CreatedOnToolsVersion = 16.2;
-					};
-				};
+                                TargetAttributes = {
+                                        90191C872D801E1300C8E23E = {
+                                                CreatedOnToolsVersion = 16.2;
+                                        };
+                                        90191D132D801E1300C8E23E = {
+                                                CreatedOnToolsVersion = 16.2;
+                                        };
+                                };
 			};
 			buildConfigurationList = 90191C832D801E1300C8E23E /* Build configuration list for PBXProject "tickscope" */;
 			developmentRegion = en;
@@ -98,30 +157,45 @@
 			productRefGroup = 90191C892D801E1300C8E23E /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
-			targets = (
-				90191C872D801E1300C8E23E /* tickscope */,
-			);
+                        targets = (
+                                90191C872D801E1300C8E23E /* tickscope */,
+                                90191D132D801E1300C8E23E /* tickscopeTests */,
+                        );
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		90191C862D801E1300C8E23E /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                90191C862D801E1300C8E23E /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+               90191D0F2D801E1300C8E23E /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		90191C842D801E1300C8E23E /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                90191C842D801E1300C8E23E /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+               90191D0D2D801E1300C8E23E /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
@@ -270,11 +344,11 @@
 			};
 			name = Debug;
 		};
-		90191C992D801E1300C8E23E /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                90191C992D801E1300C8E23E /* Release */ = {
+                        isa = XCBuildConfiguration;
+                        buildSettings = {
+                                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = tickscope/tickscope.entitlements;
 				CODE_SIGN_STYLE = Automatic;
@@ -293,10 +367,32 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.tickscope.tickscope;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
+                                SWIFT_VERSION = 5.0;
+                        };
+                        name = Release;
+                };
+               90191D102D801E1300C8E23E /* Debug */ = {
+                        isa = XCBuildConfiguration;
+                        buildSettings = {
+                                BUNDLE_LOADER = "$(TEST_HOST)";
+                                TEST_HOST = "$(BUILT_PRODUCTS_DIR)/tickscope.app/Contents/MacOS/tickscope";
+                                PRODUCT_BUNDLE_IDENTIFIER = com.tickscope.tickscopeTests;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                SWIFT_VERSION = 5.0;
+                        };
+                        name = Debug;
+                };
+               90191D112D801E1300C8E23E /* Release */ = {
+                        isa = XCBuildConfiguration;
+                        buildSettings = {
+                                BUNDLE_LOADER = "$(TEST_HOST)";
+                                TEST_HOST = "$(BUILT_PRODUCTS_DIR)/tickscope.app/Contents/MacOS/tickscope";
+                                PRODUCT_BUNDLE_IDENTIFIER = com.tickscope.tickscopeTests;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                SWIFT_VERSION = 5.0;
+                        };
+                        name = Release;
+                };
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -309,15 +405,24 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		90191C972D801E1300C8E23E /* Build configuration list for PBXNativeTarget "tickscope" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				90191C982D801E1300C8E23E /* Debug */,
-				90191C992D801E1300C8E23E /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
+                90191C972D801E1300C8E23E /* Build configuration list for PBXNativeTarget "tickscope" */ = {
+                        isa = XCConfigurationList;
+                        buildConfigurations = (
+                                90191C982D801E1300C8E23E /* Debug */,
+                                90191C992D801E1300C8E23E /* Release */,
+                        );
+                        defaultConfigurationIsVisible = 0;
+                        defaultConfigurationName = Release;
+                };
+               90191D122D801E1300C8E23E /* Build configuration list for PBXNativeTarget "tickscopeTests" */ = {
+                        isa = XCConfigurationList;
+                        buildConfigurations = (
+                                90191D102D801E1300C8E23E /* Debug */,
+                                90191D112D801E1300C8E23E /* Release */,
+                        );
+                        defaultConfigurationIsVisible = 0;
+                        defaultConfigurationName = Release;
+                };
 /* End XCConfigurationList section */
 	};
 	rootObject = 90191C802D801E1300C8E23E /* Project object */;

--- a/tickscope.xcodeproj/xcshareddata/xcschemes/tickscope.xcscheme
+++ b/tickscope.xcodeproj/xcshareddata/xcschemes/tickscope.xcscheme
@@ -7,20 +7,34 @@
       buildImplicitDependencies = "YES"
       buildArchitectures = "Automatic">
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "90191C872D801E1300C8E23E"
-               BuildableName = "tickscope.app"
-               BlueprintName = "tickscope"
-               ReferencedContainer = "container:tickscope.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
+        <BuildActionEntry
+           buildForTesting = "YES"
+           buildForRunning = "YES"
+           buildForProfiling = "YES"
+           buildForArchiving = "YES"
+           buildForAnalyzing = "YES">
+           <BuildableReference
+              BuildableIdentifier = "primary"
+              BlueprintIdentifier = "90191C872D801E1300C8E23E"
+              BuildableName = "tickscope.app"
+              BlueprintName = "tickscope"
+              ReferencedContainer = "container:tickscope.xcodeproj">
+           </BuildableReference>
+        </BuildActionEntry>
+        <BuildActionEntry
+           buildForTesting = "YES"
+           buildForRunning = "NO"
+           buildForProfiling = "NO"
+           buildForArchiving = "NO"
+           buildForAnalyzing = "NO">
+           <BuildableReference
+              BuildableIdentifier = "primary"
+              BlueprintIdentifier = "90191D132D801E1300C8E23E"
+              BuildableName = "tickscopeTests.xctest"
+              BlueprintName = "tickscopeTests"
+              ReferencedContainer = "container:tickscope.xcodeproj">
+           </BuildableReference>
+        </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/tickscope/ContentView.swift
+++ b/tickscope/ContentView.swift
@@ -73,12 +73,12 @@ struct ContentView: View {
         }
     }
     
-    private func extractStockSymbol(from optionTicker: String) -> String {
+    func extractStockSymbol(from optionTicker: String) -> String {
         let letters = optionTicker.prefix { $0.isLetter }
         return String(letters)
     }
 
-    private func formatOptionDetails(from ticker: String) -> String {
+    func formatOptionDetails(from ticker: String) -> String {
         let pattern = #"^([A-Z]+)(\d{6})([CP])(\d{8})$"#
         let regex = try? NSRegularExpression(pattern: pattern)
         let nsTicker = ticker as NSString

--- a/tickscope/OptionPriceChartView.swift
+++ b/tickscope/OptionPriceChartView.swift
@@ -30,7 +30,7 @@ struct OptionPriceChartView: View {
         }
     }
 
-    private func optionPriceRange() -> ClosedRange<Double> {
+    func optionPriceRange() -> ClosedRange<Double> {
         let prices = webSocketManager.optionTradePrices.map { $0.price }
         guard let minPrice = prices.min(),
               let maxPrice = prices.max() else {

--- a/tickscope/VolumeOptionChartView.swift
+++ b/tickscope/VolumeOptionChartView.swift
@@ -28,7 +28,7 @@ struct VolumeOptionChartView: View {
         }
     }
     
-    private func optionVolumeRange() -> ClosedRange<Int> {
+    func optionVolumeRange() -> ClosedRange<Int> {
         let volumes = webSocketManager.optionVolumes.map { $0.volume }
         
         guard let maxVolume = volumes.max(), maxVolume > 0 else {

--- a/tickscopeTests/TickscopeTests.swift
+++ b/tickscopeTests/TickscopeTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import tickscope
+
+final class TickscopeTests: XCTestCase {
+    func testFormatOptionDetailsValid() {
+        let view = ContentView()
+        let result = view.formatOptionDetails(from: "AAPL240621C00125000")
+        XCTAssertEqual(result, "AAPL Call at $125 expiring 21 Jun 2024")
+    }
+
+    func testFormatOptionDetailsInvalid() {
+        let view = ContentView()
+        let input = "INVALID"
+        XCTAssertEqual(view.formatOptionDetails(from: input), input)
+    }
+
+    func testExtractStockSymbol() {
+        let view = ContentView()
+        let ticker = "MSFT240621P00080000"
+        XCTAssertEqual(view.extractStockSymbol(from: ticker), "MSFT")
+    }
+
+    func testOptionPriceRangeEdgeCases() {
+        let manager = WebSocketManager()
+        var view = OptionPriceChartView(webSocketManager: manager)
+        // No data
+        XCTAssertEqual(view.optionPriceRange(), 0...1)
+
+        // Single price
+        manager.optionTradePrices = [Trade(price: 5.0, timestamp: Date())]
+        var range = view.optionPriceRange()
+        XCTAssertEqual(range.lowerBound, 4.5, accuracy: 0.0001)
+        XCTAssertEqual(range.upperBound, 5.5, accuracy: 0.0001)
+
+        // Multiple prices
+        manager.optionTradePrices = [Trade(price: 10.0, timestamp: Date()),
+                                     Trade(price: 20.0, timestamp: Date())]
+        range = view.optionPriceRange()
+        XCTAssertEqual(range.lowerBound, 9.0, accuracy: 0.0001)
+        XCTAssertEqual(range.upperBound, 21.0, accuracy: 0.0001)
+    }
+
+    func testOptionVolumeRangeEdgeCases() {
+        let manager = WebSocketManager()
+        var view = VolumeOptionChartView(webSocketManager: manager)
+        // No data
+        XCTAssertEqual(view.optionVolumeRange(), 0...10)
+
+        // Max zero
+        manager.optionVolumes = [VolumeData(volume: 0, timestamp: Date())]
+        XCTAssertEqual(view.optionVolumeRange(), 0...10)
+
+        // Positive volumes
+        manager.optionVolumes = [VolumeData(volume: 10, timestamp: Date()),
+                                 VolumeData(volume: 20, timestamp: Date())]
+        XCTAssertEqual(view.optionVolumeRange(), 0...22)
+    }
+}


### PR DESCRIPTION
## Summary
- expose helper methods for testing
- create a unit test target and sample test suite
- cover `formatOptionDetails`, `extractStockSymbol`, and chart range helpers

## Testing
- `xcodebuild -scheme tickscope -destination 'platform=macOS' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688633bea03c83258b48d564dacfe911