### PR TITLE
Fix chart time axis

### DIFF
--- a/tickscope/BidAskOptionChartView.swift
+++ b/tickscope/BidAskOptionChartView.swift
@@ -25,6 +25,12 @@ struct BidAskOptionChartView: View {
                     .foregroundStyle(.green)
                 }
             }
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .minute)) { value in
+                    AxisGridLine()
+                    AxisValueLabel(format: .dateTime.hour().minute())
+                }
+            }
             .chartYScale(domain: bidAskOptionRange())
         }
     }

--- a/tickscope/BidAskStockChartView.swift
+++ b/tickscope/BidAskStockChartView.swift
@@ -25,6 +25,12 @@ struct BidAskStockChartView: View {
                     .foregroundStyle(.green)
                 }
             }
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .minute)) { value in
+                    AxisGridLine()
+                    AxisValueLabel(format: .dateTime.hour().minute())
+                }
+            }
             .chartYScale(domain: bidAskStockRange())
         }
     }

--- a/tickscope/OptionPriceChartView.swift
+++ b/tickscope/OptionPriceChartView.swift
@@ -26,6 +26,12 @@ struct OptionPriceChartView: View {
                     .foregroundStyle(.purple)
                 }
             }
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .minute)) { value in
+                    AxisGridLine()
+                    AxisValueLabel(format: .dateTime.hour().minute())
+                }
+            }
             .chartYScale(domain: optionPriceRange())
         }
     }

--- a/tickscope/StockPriceChartView.swift
+++ b/tickscope/StockPriceChartView.swift
@@ -19,6 +19,12 @@ struct StockPriceChartView: View {
                     .foregroundStyle(.blue)
                 }
             }
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .minute)) { value in
+                    AxisGridLine()
+                    AxisValueLabel(format: .dateTime.hour().minute())
+                }
+            }
             .chartYScale(domain: priceRange())
         }
     }

--- a/tickscope/VolumeOptionChartView.swift
+++ b/tickscope/VolumeOptionChartView.swift
@@ -24,6 +24,12 @@ struct VolumeOptionChartView: View {
                 )
                 .foregroundStyle(.orange)
             }
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .minute)) { value in
+                    AxisGridLine()
+                    AxisValueLabel(format: .dateTime.hour().minute())
+                }
+            }
             .chartYScale(domain: optionVolumeRange())
         }
     }

--- a/tickscope/VolumeStockChartView.swift
+++ b/tickscope/VolumeStockChartView.swift
@@ -27,6 +27,12 @@ struct VolumeStockChartView: View {
                     .foregroundStyle(.blue)
                 }
             }
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .minute)) { value in
+                    AxisGridLine()
+                    AxisValueLabel(format: .dateTime.hour().minute())
+                }
+            }
             .chartYScale(domain: stockVolumeRange())
         }
     }


### PR DESCRIPTION
## Summary
- add explicit `.chartXAxis` formatting to all chart views to fix axis jumping to seconds

## Testing
- `pytest -q` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_6888fff54b388325a5f60b58fef78e02