### PR TITLE
Add Polygon IV fetcher with caching

### DIFF
--- a/src/datafeeds/polygon_iv.cpp
+++ b/src/datafeeds/polygon_iv.cpp
@@ -1,0 +1,78 @@
+#include "polygon_iv.h"
+
+#include <curl/curl.h>
+#include <string>
+#include <utility>
+
+namespace {
+size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
+    std::string *s = static_cast<std::string *>(userp);
+    s->append(static_cast<char *>(contents), size * nmemb);
+    return size * nmemb;
+}
+} // namespace
+
+PolygonIVFetcher::PolygonIVFetcher(std::string apiKey, std::chrono::seconds cacheDuration)
+    : apiKey_(std::move(apiKey)), cacheDuration_(cacheDuration) {}
+
+bool PolygonIVFetcher::isStale(const CacheEntry &entry) const {
+    return (std::chrono::steady_clock::now() - entry.timestamp) > cacheDuration_;
+}
+
+std::optional<double> PolygonIVFetcher::fetchFromPolygon(const std::string &optionSymbol) {
+    CURL *curl = curl_easy_init();
+    if (!curl) return std::nullopt;
+
+    std::string url = "https://api.polygon.io/v2/snapshot/options/" + optionSymbol + "?apiKey=" + apiKey_;
+    std::string buffer;
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buffer);
+
+    CURLcode res = curl_easy_perform(curl);
+    curl_easy_cleanup(curl);
+
+    if(res != CURLE_OK) {
+        return std::nullopt;
+    }
+
+    auto pos = buffer.find("\"implied_volatility\":");
+    if(pos == std::string::npos) return std::nullopt;
+    pos += std::string("\"implied_volatility\":").size();
+    size_t end = buffer.find_first_of(",}", pos);
+    if(end == std::string::npos) return std::nullopt;
+
+    double iv = 0.0;
+    try {
+        iv = std::stod(buffer.substr(pos, end - pos));
+    } catch(const std::exception &) {
+        return std::nullopt;
+    }
+    return iv;
+}
+
+std::optional<double> PolygonIVFetcher::getIV(const std::string &optionSymbol) {
+    auto now = std::chrono::steady_clock::now();
+    auto it = cache_.find(optionSymbol);
+    if (it != cache_.end() && !isStale(it->second)) {
+        return it->second.iv;
+    }
+
+    auto iv = fetchFromPolygon(optionSymbol);
+    if (iv) {
+        cache_[optionSymbol] = { *iv, now };
+    }
+    return iv;
+}
+
+void PolygonIVFetcher::notifyMajorMove(const std::string &underlyingSymbol) {
+    for (auto it = cache_.begin(); it != cache_.end(); ) {
+        if (it->first.find(underlyingSymbol) != std::string::npos) {
+            it = cache_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+

--- a/src/datafeeds/polygon_iv.h
+++ b/src/datafeeds/polygon_iv.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <optional>
+#include <chrono>
+
+// Fetches implied volatility for option contracts using the Polygon.io
+// REST snapshot endpoint. Results are cached for a configurable
+// duration to avoid hitting the API too frequently.
+class PolygonIVFetcher {
+public:
+    // apiKey: Polygon.io API key.
+    // cacheDuration: how long entries remain valid before refreshing.
+    explicit PolygonIVFetcher(std::string apiKey,
+                              std::chrono::seconds cacheDuration = std::chrono::seconds(60));
+
+    // Retrieve the implied volatility for the given option contract symbol.
+    // Returns std::nullopt on network or parse errors.
+    std::optional<double> getIV(const std::string &optionSymbol);
+
+    // Clears cached entries for contracts related to an underlying symbol.
+    // Call this when external signals indicate a major market move.
+    void notifyMajorMove(const std::string &underlyingSymbol);
+
+private:
+    struct CacheEntry {
+        double iv{};
+        std::chrono::steady_clock::time_point timestamp{};
+    };
+
+    std::optional<double> fetchFromPolygon(const std::string &optionSymbol);
+    bool isStale(const CacheEntry &entry) const;
+
+    std::string apiKey_;
+    std::chrono::seconds cacheDuration_;
+    std::unordered_map<std::string, CacheEntry> cache_;
+};
+


### PR DESCRIPTION
## Summary
- add PolygonIVFetcher to retrieve option IV from Polygon snapshots
- cache IV values per contract and refresh on expiration or market move

## Testing
- `g++ -std=c++17 -c src/datafeeds/polygon_iv.cpp`
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891df06d7d0832594ba77dc4ac71f30