### PR TITLE
Add throttled price manager for option pricing

### DIFF
--- a/src/pricing/price_manager.cpp
+++ b/src/pricing/price_manager.cpp
@@ -1,0 +1,50 @@
+#include "price_manager.h"
+#include "baw_pricer.h"
+#include "binomial_pricer.h"
+
+#include <cmath>
+
+PriceManager::PriceManager(OptionPricingInput baseInput)
+    : input_(baseInput) {
+    // Initial calculation so UI has values immediately.
+    bawPrice_ = baw_price(input_);
+    binomialPrice_ = binomial_price(input_);
+    lastUpdate_ = std::chrono::steady_clock::now();
+}
+
+bool PriceManager::needsRecalc(double spot, double iv, double time,
+                               double bid, double ask) const {
+    if (input_.spot > 0.0 && std::fabs(spot - input_.spot) / input_.spot > spotThreshold_)
+        return true;
+    if (input_.impliedVol > 0.0 && std::fabs(iv - input_.impliedVol) / input_.impliedVol > ivThreshold_)
+        return true;
+    if (std::fabs(time - input_.timeToExpiry) > timeThreshold_)
+        return true;
+    if (lastBid_ > 0.0 && std::fabs(bid - lastBid_) / lastBid_ > bidAskThreshold_)
+        return true;
+    if (lastAsk_ > 0.0 && std::fabs(ask - lastAsk_) / lastAsk_ > bidAskThreshold_)
+        return true;
+    return false;
+}
+
+bool PriceManager::throttled() const {
+    return std::chrono::steady_clock::now() - lastUpdate_ < throttleInterval_;
+}
+
+void PriceManager::update(double spot, double iv, double time,
+                          double bid, double ask) {
+    if (!needsRecalc(spot, iv, time, bid, ask))
+        return;
+    if (throttled())
+        return;
+
+    input_.spot = spot;
+    input_.impliedVol = iv;
+    input_.timeToExpiry = time;
+    bawPrice_ = baw_price(input_);
+    binomialPrice_ = binomial_price(input_);
+    lastBid_ = bid;
+    lastAsk_ = ask;
+    lastUpdate_ = std::chrono::steady_clock::now();
+}
+

--- a/src/pricing/price_manager.h
+++ b/src/pricing/price_manager.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <chrono>
+#include "option_pricing_input.h"
+
+// Manages option pricing recalculations based on market data changes.
+class PriceManager {
+public:
+    explicit PriceManager(OptionPricingInput baseInput);
+
+    // Update market data. Recalculates prices if thresholds are
+    // exceeded and throttling allows.
+    void update(double spot, double impliedVol, double timeToExpiry,
+                double bid, double ask);
+
+    double bawPrice() const { return bawPrice_; }
+    double binomialPrice() const { return binomialPrice_; }
+    double lastBid() const { return lastBid_; }
+    double lastAsk() const { return lastAsk_; }
+    const OptionPricingInput& input() const { return input_; }
+
+private:
+    bool needsRecalc(double spot, double iv, double time,
+                     double bid, double ask) const;
+    bool throttled() const;
+
+    OptionPricingInput input_{};
+    double lastBid_ = 0.0;
+    double lastAsk_ = 0.0;
+    double bawPrice_ = 0.0;
+    double binomialPrice_ = 0.0;
+
+    std::chrono::steady_clock::time_point lastUpdate_;
+    std::chrono::seconds throttleInterval_ = std::chrono::seconds(3);
+
+    static constexpr double spotThreshold_ = 0.001;      // 0.1%
+    static constexpr double ivThreshold_ = 0.01;          // 1%
+    static constexpr double bidAskThreshold_ = 0.001;    // 0.1%
+    static constexpr double timeThreshold_ = 1.0 / 86400.0; // 1 second in years
+};
+


### PR DESCRIPTION
## Summary
- Add `PriceManager` class that monitors spot, IV, time and bid/ask changes
- Trigger BAW and binomial recomputation when thresholds exceeded
- Throttle updates to avoid recalculation on rapid ticks and expose latest prices to UI

## Testing
- `g++ -std=c++17 -I src/pricing -c src/pricing/price_manager.cpp`
- `g++ -std=c++17 -I src/pricing -c src/pricing/baw_pricer.cpp src/pricing/binomial_pricer.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6891e8e6862c8325972009368f967511