### PR TITLE
Format history menu tickers for readability

### DIFF
--- a/tickscope/ContentView.swift
+++ b/tickscope/ContentView.swift
@@ -22,8 +22,8 @@ struct ContentView: View {
                         } else {
                             ForEach(historyTickers, id: \.self) { ticker in
                                 HStack {
-                                    Button(ticker) {
-                                        scopeTicker(ticker)
+                                    Button(action: { scopeTicker(ticker) }) {
+                                        Text(formatOptionDetails(from: ticker))
                                     }
                                     Button(action: { removeHistoryTicker(ticker) }) {
                                         Image(systemName: "xmark")
@@ -142,7 +142,7 @@ struct ContentView: View {
         guard let date = formatter.date(from: dateString) else {
             return ticker
         }
-        formatter.dateFormat = "d MMM yyyy"
+        formatter.dateFormat = "d MMMM yyyy"
         let formattedDate = formatter.string(from: date)
 
         let strikeValue = (Double(strikeString) ?? 0) / 1000.0

--- a/tickscopeTests/tickscopeTests.swift
+++ b/tickscopeTests/tickscopeTests.swift
@@ -13,7 +13,7 @@ final class TickscopeTests: XCTestCase {
     func testFormatOptionDetailsValid() {
         let view = ContentView()
         let result = view.formatOptionDetails(from: "AAPL240621C00125000")
-        XCTAssertEqual(result, "AAPL Call at $125 expiring 21 Jun 2024")
+        XCTAssertEqual(result, "AAPL Call at $125 expiring 21 June 2024")
     }
 
     func testFormatOptionDetailsInvalid() {


### PR DESCRIPTION
## Summary
- Show formatted ticker details in the History menu
- Present option expiration dates with full month names

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f13d8bd808325a4114b24aafa38ec