### PR TITLE
Use platform-specific toolbar placements in HistoryView

### DIFF
--- a/tickscope/HistoryView.swift
+++ b/tickscope/HistoryView.swift
@@ -14,6 +14,7 @@ struct HistoryView: View {
             }
             .navigationTitle("History")
             .toolbar {
+#if os(iOS)
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Done") {
                         dismiss()
@@ -27,6 +28,21 @@ struct HistoryView: View {
                         }
                     }
                 }
+#else
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .destructiveAction) {
+                    if !historyTickers.isEmpty {
+                        Button("Clear All") {
+                            historyTickers.removeAll()
+                            UserDefaults.standard.set(historyTickers, forKey: "historyTickers")
+                        }
+                    }
+                }
+#endif
             }
         }
     }


### PR DESCRIPTION
## Summary
- adjust HistoryView toolbar placements for modern APIs
- add platform conditional compilation to maintain legacy iOS behavior

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f1c1c90bc8325a8877424175263c9