### PR TITLE
Remove iOS-specific toolbar code from HistoryView

### DIFF
--- a/tickscope/HistoryView.swift
+++ b/tickscope/HistoryView.swift
@@ -14,21 +14,6 @@ struct HistoryView: View {
             }
             .navigationTitle("History")
             .toolbar {
-#if os(iOS)
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Done") {
-                        dismiss()
-                    }
-                }
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    if !historyTickers.isEmpty {
-                        Button("Clear All") {
-                            historyTickers.removeAll()
-                            UserDefaults.standard.set(historyTickers, forKey: "historyTickers")
-                        }
-                    }
-                }
-#else
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") {
                         dismiss()
@@ -42,7 +27,6 @@ struct HistoryView: View {
                         }
                     }
                 }
-#endif
             }
         }
     }


### PR DESCRIPTION
## Summary
- Clean up HistoryView toolbar to only use macOS placements.

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689f1e5726108325810e0182abb1e3a3