### PR TITLE
Improve ticker history view

### DIFF
--- a/tickscope/ContentView.swift
+++ b/tickscope/ContentView.swift
@@ -84,7 +84,10 @@ struct ContentView: View {
             .padding(.vertical, 15)
         }
         .sheet(isPresented: $showHistory) {
-            HistoryView(historyTickers: $historyTickers)
+            HistoryView(historyTickers: $historyTickers) { ticker in
+                optionTicker = ticker
+                scopeTicker(ticker)
+            }
         }
     }
 

--- a/tickscope/HistoryView.swift
+++ b/tickscope/HistoryView.swift
@@ -2,15 +2,32 @@ import SwiftUI
 
 struct HistoryView: View {
     @Binding var historyTickers: [String]
+    var onSelect: ((String) -> Void)? = nil
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         NavigationView {
             List {
-                ForEach(historyTickers, id: \.self) { ticker in
-                    Text(ticker)
+                if historyTickers.isEmpty {
+                    Text("No recent tickers")
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(historyTickers, id: \.self) { ticker in
+                        Button {
+                            onSelect?(ticker)
+                            dismiss()
+                        } label: {
+                            Label(ticker, systemImage: "clock")
+                        }
+                        .swipeActions(edge: .trailing) {
+                            Button(role: .destructive) {
+                                deleteTicker(ticker)
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                    }
                 }
-                .onDelete(perform: delete)
             }
             .navigationTitle("History")
             .toolbar {
@@ -31,9 +48,11 @@ struct HistoryView: View {
         }
     }
 
-    private func delete(at offsets: IndexSet) {
-        historyTickers.remove(atOffsets: offsets)
-        UserDefaults.standard.set(historyTickers, forKey: "historyTickers")
+    private func deleteTicker(_ ticker: String) {
+        if let index = historyTickers.firstIndex(of: ticker) {
+            historyTickers.remove(at: index)
+            UserDefaults.standard.set(historyTickers, forKey: "historyTickers")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- revamp history view with selectable rows, swipe-to-delete, and empty-state messaging
- allow quick reloading of historical tickers from history sheet

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689f400f36008325b11bee362841121e