### PR TITLE
Ensure history view displays at a usable size on macOS

### DIFF
--- a/tickscope/HistoryView.swift
+++ b/tickscope/HistoryView.swift
@@ -46,6 +46,8 @@ struct HistoryView: View {
                 }
             }
         }
+        // Ensure the sheet has a reasonable size on macOS
+        .frame(minWidth: 300, minHeight: 400)
     }
 
     private func deleteTicker(_ ticker: String) {


### PR DESCRIPTION
## Summary
- prevent history sheet from collapsing by setting a minimum frame size

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project tickscope.xcodeproj -scheme tickscope -sdk macosx` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_689f42bff5348325954700546b677649