### PR TITLE
Improve history view window size and labels

### DIFF
--- a/tickscope/ContentView.swift
+++ b/tickscope/ContentView.swift
@@ -109,36 +109,36 @@ struct ContentView: View {
         let letters = optionTicker.prefix { $0.isLetter }
         return String(letters)
     }
+}
 
-    func formatOptionDetails(from ticker: String) -> String {
-        let pattern = #"^([A-Z]+)(\d{6})([CP])(\d{8})$"#
-        let regex = try? NSRegularExpression(pattern: pattern)
-        let nsTicker = ticker as NSString
+func formatOptionDetails(from ticker: String) -> String {
+    let pattern = #"^([A-Z]+)(\d{6})([CP])(\d{8})$"#
+    let regex = try? NSRegularExpression(pattern: pattern)
+    let nsTicker = ticker as NSString
 
-        guard let match = regex?.firstMatch(in: ticker, range: NSRange(location: 0, length: nsTicker.length)),
-              match.numberOfRanges == 5 else {
-            return ticker
-        }
-
-        let stock = nsTicker.substring(with: match.range(at: 1))
-        let dateString = nsTicker.substring(with: match.range(at: 2))
-        let type = nsTicker.substring(with: match.range(at: 3)) == "C" ? "Call" : "Put"
-        let strikeString = nsTicker.substring(with: match.range(at: 4))
-
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyMMdd"
-        guard let date = formatter.date(from: dateString) else {
-            return ticker
-        }
-        formatter.dateFormat = "d MMMM yyyy"
-        let formattedDate = formatter.string(from: date)
-
-        let strikeValue = (Double(strikeString) ?? 0) / 1000.0
-        let formattedStrike = strikeValue.truncatingRemainder(dividingBy: 1) == 0 ?
-            String(format: "$%.0f", strikeValue) : String(format: "$%.2f", strikeValue)
-
-        return "\(stock) \(type) at \(formattedStrike) expiring \(formattedDate)"
+    guard let match = regex?.firstMatch(in: ticker, range: NSRange(location: 0, length: nsTicker.length)),
+          match.numberOfRanges == 5 else {
+        return ticker
     }
+
+    let stock = nsTicker.substring(with: match.range(at: 1))
+    let dateString = nsTicker.substring(with: match.range(at: 2))
+    let type = nsTicker.substring(with: match.range(at: 3)) == "C" ? "Call" : "Put"
+    let strikeString = nsTicker.substring(with: match.range(at: 4))
+
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyMMdd"
+    guard let date = formatter.date(from: dateString) else {
+        return ticker
+    }
+    formatter.dateFormat = "d MMMM yyyy"
+    let formattedDate = formatter.string(from: date)
+
+    let strikeValue = (Double(strikeString) ?? 0) / 1000.0
+    let formattedStrike = strikeValue.truncatingRemainder(dividingBy: 1) == 0 ?
+        String(format: "$%.0f", strikeValue) : String(format: "$%.2f", strikeValue)
+
+    return "\(stock) \(type) at \(formattedStrike) expiring \(formattedDate)"
 }
 
 #Preview {

--- a/tickscope/HistoryView.swift
+++ b/tickscope/HistoryView.swift
@@ -17,7 +17,7 @@ struct HistoryView: View {
                             onSelect?(ticker)
                             dismiss()
                         } label: {
-                            Label(ticker, systemImage: "clock")
+                            Label(formatOptionDetails(from: ticker), systemImage: "clock")
                         }
                         .swipeActions(edge: .trailing) {
                             Button(role: .destructive) {
@@ -47,7 +47,7 @@ struct HistoryView: View {
             }
         }
         // Ensure the sheet has a reasonable size on macOS
-        .frame(minWidth: 300, minHeight: 400)
+        .frame(minWidth: 600, minHeight: 800)
     }
 
     private func deleteTicker(_ ticker: String) {

--- a/tickscopeTests/tickscopeTests.swift
+++ b/tickscopeTests/tickscopeTests.swift
@@ -11,15 +11,13 @@ import XCTest
 final class TickscopeTests: XCTestCase {
 
     func testFormatOptionDetailsValid() {
-        let view = ContentView()
-        let result = view.formatOptionDetails(from: "AAPL240621C00125000")
+        let result = formatOptionDetails(from: "AAPL240621C00125000")
         XCTAssertEqual(result, "AAPL Call at $125 expiring 21 June 2024")
     }
 
     func testFormatOptionDetailsInvalid() {
-        let view = ContentView()
         let input = "INVALID"
-        XCTAssertEqual(view.formatOptionDetails(from: input), input)
+        XCTAssertEqual(formatOptionDetails(from: input), input)
     }
 
     func testExtractStockSymbol() {


### PR DESCRIPTION
## Summary
- show option history entries with human-readable contract descriptions
- double default size of the history window
- expose option contract formatter for reuse

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689f4807fc348325a99a8741773aa03f